### PR TITLE
Add pointer equality check in generated equals() method.

### DIFF
--- a/src/main/groovy/pl/mjedynak/idea/plugins/generator/EqualsGenerator.groovy
+++ b/src/main/groovy/pl/mjedynak/idea/plugins/generator/EqualsGenerator.groovy
@@ -15,8 +15,8 @@ class EqualsGenerator {
             PsiElementFactory factory = getFactory(equalsPsiFields[0])
             StringBuilder methodText = new StringBuilder()
             methodText << '@Override public boolean equals(Object obj) {'
-            methodText << ' if (obj == null) {return false;}'
-            methodText << ' if (getClass() != obj.getClass()) {return false;}'
+            methodText << ' if (this == obj) {return true;}'
+            methodText << ' if (obj == null || getClass() != obj.getClass()) {return false;}'
             methodText << " final ${psiClass.name} other = (${psiClass.name}) obj;"
             methodText << ' return '
             equalsPsiFields.eachWithIndex { field, index ->


### PR DESCRIPTION
Checking for pointer equality in equals() adds a quick short-circuit in the case that you're comparing an object to itself.
